### PR TITLE
add threshhold if sizereport shows file(s) larger than threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Display the last total row.
 - ``gzip`` (default: false)
 Toggle the Gzipped size column.
 
+- ``fail`` (default: false)
+Allows you to fail your Gulp task if a file exceeds a threshold.
+
 ```js
 var gulp = require('gulp');
 var sizereport = require('gulp-sizereport');
@@ -114,7 +117,7 @@ gulp.task('sizereport', function () {
             },
             'pin.js': {
                 'maxMinifiedSize': 5500,
-                'maxMinifiedGzippedSize': 2500 
+                'maxMinifiedGzippedSize': 2500
             }
         }));
 });

--- a/index.js
+++ b/index.js
@@ -140,10 +140,8 @@ module.exports = function (options) {
             }
 
             console.log(table.toString());
-            if (options.fail) {
-                if(fail) {
-                    callback(new new PluginError('gulp-sizereport', 'One or more file(s) exceeded the maximum size defined in options.'));
-                }
+            if (options.fail && fail) {
+                callback(new new PluginError('gulp-sizereport', 'One or more file(s) exceeded the maximum size defined in options.'));
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -13,11 +13,13 @@ module.exports = function (options) {
     options.gzip     = (options.gzip     !== undefined) ? options.gzip     : false;
     options.minifier = (options.minifier !== undefined) ? options.minifier : null;
     options.total    = (options.total    !== undefined) ? options.total    : true;
+    options.fail     = (options.fail     !== undefined) ? options.fail    : false;
 
     var tableHeadCols = [
         'File',
         'Original'
-    ];
+    ],
+    fail = false;
 
     if (options.gzip) {
         tableHeadCols.push('Gzipped');
@@ -60,6 +62,7 @@ module.exports = function (options) {
 
         if (value && size > value) {
             beeper();
+            fail = true;
 
             return colors.red(prettyBytes(size));
         }
@@ -74,7 +77,7 @@ module.exports = function (options) {
         }
 
         if (file.isStream()) {
-            callback(new PluginError('gulp-size', 'Streaming not supported'));
+            callback(new PluginError('gulp-sizereport', 'Streaming not supported'));
             return;
         }
 
@@ -83,7 +86,7 @@ module.exports = function (options) {
         totalGzippedSize += gzippedSize;
         fileCount ++;
 
-        var row = [ 
+        var row = [
             file.relative,
             getSizeToDisplay(file.contents.length, 'maxSize', file.relative)
         ];
@@ -126,10 +129,10 @@ module.exports = function (options) {
                 }
 
                 if (options.minifier) {
-                    row.push(colors.bold(getSizeToDisplay(totalMinifiedSize, 'maxTotalMinifiedSize', '*')));    
+                    row.push(colors.bold(getSizeToDisplay(totalMinifiedSize, 'maxTotalMinifiedSize', '*')));
 
                     if (options.gzip) {
-                        row.push(colors.bold(getSizeToDisplay(totalMinifiedGzippedSize, 'maxTotalMinifiedGzippedSize', '*')));                        
+                        row.push(colors.bold(getSizeToDisplay(totalMinifiedGzippedSize, 'maxTotalMinifiedGzippedSize', '*')));
                     }
                 }
 
@@ -137,6 +140,11 @@ module.exports = function (options) {
             }
 
             console.log(table.toString());
+            if (options.fail) {
+                if(fail) {
+                    callback(new new PluginError('gulp-sizereport', 'One or more file(s) exceeded the maximum size defined in options.'));
+                }
+            }
         }
 
         callback();


### PR DESCRIPTION
For Open Source Friday: add in functionality to return an error when the size of one or more files exceeds the set threshold. Ideal for DevOps when we want to fail a build if an asset grows too large. 

#11 