### PR TITLE
Fix Fail Callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/*
 
 NOTE.md
+
+.idea

--- a/index.js
+++ b/index.js
@@ -141,7 +141,8 @@ module.exports = function (options) {
 
             console.log(table.toString());
             if (options.fail && fail) {
-                callback(new new PluginError('gulp-sizereport', 'One or more file(s) exceeded the maximum size defined in options.'));
+                callback(new PluginError('gulp-sizereport', 'One or more file(s) exceeded the maximum size defined in options.'));
+                return;
             }
         }
 


### PR DESCRIPTION
## Issue
Using the `fail` option results in a `TypeError`:
```js
gulp.task('check-asset-sizes', function () {
    return gulp.src('build/**/*')
        .pipe(sizereport({
            fail: true,
            '*': {
                'maxSize': 1000000
            },
        }));
});
```
```sh
[16:00:52] 'check-asset-sizes' errored after 689 ms
[16:00:52] TypeError: (intermediate value) is not a constructor
    at DestroyableTransform._flush (REDACTED/node_modules/gulp-sizereport/index.js:144:26)
    at DestroyableTransform.prefinish (REDACTED/node_modules/readable-stream/lib/_stream_transform.js:138:10)
    at DestroyableTransform.emit (events.js:182:13)
    at DestroyableTransform.EventEmitter.emit (domain.js:460:23)
    at prefinish (REDACTED/node_modules/readable-stream/lib/_stream_writable.js:619:14)
    at finishMaybe (REDACTED/node_modules/readable-stream/lib/_stream_writable.js:627:5)
    at endWritable (REDACTED/node_modules/readable-stream/lib/_stream_writable.js:638:3)
    at DestroyableTransform.Writable.end (REDACTED/node_modules/readable-stream/lib/_stream_writable.js:594:41)
    at DestroyableTransform.onend (REDACTED/node_modules/readable-stream/lib/_stream_readable.js:577:10)
    at Object.onceWrapper (events.js:273:13)
```

## Solution
- remove extraneous `new`
- `return` after invoking `callback`
```sh
[16:06:56] 'check-asset-sizes' errored after 657 ms
[16:06:56] Error in plugin "gulp-sizereport"
Message:
    One or more file(s) exceeded the maximum size defined in options.
Details:
    domainEmitter: [object Object]
    domain: [object Object]
    domainThrown: false
```